### PR TITLE
Fixed ldap 'SSL routines error'

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -115,7 +115,7 @@ class LDAPConnection:
             self._socket.connect(sa)
         else:
             # Switching to TLS now
-            ctx = SSL.Context(SSL.TLSv1_METHOD)
+            ctx = SSL.Context(SSL.TLSv1_2_METHOD)
             # ctx.set_cipher_list('RC4')
             self._socket = SSL.Connection(ctx, self._socket)
             self._socket.connect(sa)

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -115,7 +115,7 @@ class LDAPConnection:
             self._socket.connect(sa)
         else:
             # Switching to TLS now
-            ctx = SSL.Context(SSL.TLSv1_2_METHOD)
+            ctx = SSL.Context(SSL.TLS_METHOD)
             # ctx.set_cipher_list('RC4')
             self._socket = SSL.Connection(ctx, self._socket)
             self._socket.connect(sa)


### PR DESCRIPTION
Hello,

You fixed this error sometime ago for MSSQL:
```
OpenSSL.SSL.Error: [('SSL routines', '', 'internal error')]
```

However, this also happen with LDAPS (and maybe other protocol ?), in this PR I simply applied the same fix as you dicsussed in the orignal PR (https://github.com/SecureAuthCorp/impacket/issues/856), since you are using this fork for CME, I'm doing the PR here, maybe I should aswell do it on the original Impacket repo.